### PR TITLE
Dk eth infra fluentd mev boost

### DIFF
--- a/log/fluent.conf.tpl
+++ b/log/fluent.conf.tpl
@@ -62,12 +62,12 @@
   <parse>
     @type multi_format
     <pattern>
-      @type json
+      format json
       time_type string
       time_format %Y-%m-%dT%H:%M:%S%z
     </pattern>
     <pattern>
-      @type json
+      format json
       time_type string
       time_format %Y-%m-%dT%H:%M:%S.%N%z
     </pattern>

--- a/log/fluent.conf.tpl
+++ b/log/fluent.conf.tpl
@@ -60,9 +60,17 @@
   @type parser
   key_name log
   <parse>
-    @type json
-    time_type string
-    time_format %Y-%m-%dT%H:%M:%S%z
+    @type multi_format
+    <pattern>
+      @type json
+      time_type string
+      time_format %Y-%m-%dT%H:%M:%S%z
+    </pattern>
+    <pattern>
+      @type json
+      time_type string
+      time_format %Y-%m-%dT%H:%M:%S.%N%z
+    </pattern>
   </parse>
 </filter>
 


### PR DESCRIPTION
This pr updates the fluentd config to use the [fluent-plugin-multi-format-parser](https://github.com/repeatedly/fluent-plugin-multi-format-parser#for-v10) to allow the parsing of JSON logs with a different format produced by the MEV Boost Plugin.

This has been deployed to our dev instance and tested (using a rebuilt dockerfile and nomad job currently in this pr https://github.com/cephalopodequipment/infra/pull/748

Testing and review in elasticsearch shows that this plugin is now working correctly.

![Screenshot 2024-04-01 at 5 31 53 PM](https://github.com/cephalopodequipment/config/assets/99262/81a30a52-40ec-401b-a33c-b83fb0debe5b)
