### PR TITLE
Update fuel sidecar address format in app.toml

### DIFF
--- a/cosmos-sdk/0.50.x/app.toml.tpl
+++ b/cosmos-sdk/0.50.x/app.toml.tpl
@@ -266,6 +266,6 @@ memory_cache_size = 3000
 # This dictates whether the Sidecar will be queried.
 enabled = {{ keyOrDefault (print (env "FUEL_SIDECAR_CONSUL_PATH") "/base.sidecar.enabled") "false" }}
 # This defines the Sidecar server to listen to.
-address = "http://{{ env "NOMAD_IP_grpc" }}:{{ env "NOMAD_PORT_grpc" }}"
+address = "{{ env "NOMAD_IP_grpc" }}:{{ env "NOMAD_PORT_grpc" }}"
 # This defines how long the client should wait for responses.
 timeout = "5s"


### PR DESCRIPTION
The fuel team requested that we format the address parameter in the Fuel Sidecar section to not include http. This PR makes that change.