### PR TITLE
Revert Fuel Testnet config changes

### DIFF
--- a/cosmos-sdk/0.50.x/app.toml.tpl
+++ b/cosmos-sdk/0.50.x/app.toml.tpl
@@ -266,6 +266,6 @@ memory_cache_size = 3000
 # This dictates whether the Sidecar will be queried.
 enabled = {{ keyOrDefault (print (env "FUEL_SIDECAR_CONSUL_PATH") "/base.sidecar.enabled") "false" }}
 # This defines the Sidecar server to listen to.
-address = "{{ env "NOMAD_IP_grpc" }}:{{ env "NOMAD_PORT_grpc" }}"
+address = "http://{{ env "NOMAD_IP_grpc" }}:{{ env "NOMAD_PORT_grpc" }}"
 # This defines how long the client should wait for responses.
 timeout = "5s"


### PR DESCRIPTION
Sorry, the previous change suggested by the Fuel team was not correct and the validator failed to start with the new config with error:

```
panic: sidecar address must be valid: parse "10.20.30.106:27012": invalid URI for request
```