### PR TITLE
fix conf file for txindex and rpcauth

### DIFF
--- a/babylon/bitcoin/bitcoin-conf.toml.tpl
+++ b/babylon/bitcoin/bitcoin-conf.toml.tpl
@@ -1,17 +1,18 @@
 # bitcoin.conf file
 server=1
 # rpcauth - sets the rpcuser and rpcpassword so the password doesnt need 
-# to be displayed in full text - these values are stored in vault
-# and this tool https://jlopp.github.io/bitcoin-core-rpc-auth-generator/
-# can be used to generate an rpcauth string
-{{- with secret "static_secrets/babylon-testnet/btc-fullnode" }}
-rpcauth="{{ .Data.data.rpcauth }}"
+# to be displayed in full text - these values are stored in vault.
+# Use this tool https://jlopp.github.io/bitcoin-core-rpc-auth-generator/
+# or use the python script here 
+# https://github.com/bitcoin/bitcoin/blob/master/share/rpcauth/README.md
+# to generate an rpcauth string
+{{- with secret (printf "static_secrets/babylon/%s" (env "BTC_NODE_TYPE")) }}
+rpcauth={{ .Data.data.rpcauth }}
 {{- end}}
-
 # rpc cookie file this allows authentication to only those that have access to the cookie location
 rpccookiefile={{key (print (env "CONSUL_PATH") "/btc_home_dir")}}/.cookie
 # txindex turns on transaction indexing values 0 = no tx indexing or 1 = tx indexing
-txindex=={{ env "BTC_TX_INDEX" }}
+txindex={{ env "BTC_TX_INDEX" }}
 chain={{ key (print (env "CONSUL_PATH") "/chain_id")}}
 [{{ key (print (env "CONSUL_PATH") "/chain_id")}}]
 rpcbind=0.0.0.0

--- a/babylon/covenant-signer/config.toml.tpl
+++ b/babylon/covenant-signer/config.toml.tpl
@@ -11,7 +11,7 @@
 host = "{{ .Address }}:{{ .Port }}"
 {{- end }}
 {{- end }}
-{{- with secret "static_secrets/babylon-testnet/btc-fullnode" }}
+{{- with secret "static_secrets/babylon/fullnode" }}
 # Btc node user
 user = "{{ .Data.data.rpcuser }}"
 # Btc node password
@@ -28,7 +28,7 @@ host = "{{ .Address }}:{{ .Port }}"
 {{- end }}
 {{- end }}
 # TODO: consider reading user/pass from command line
-{{- with secret "static_secrets/babylon-testnet/btc-signer" }}
+{{- with secret "static_secrets/babylon/signer-node" }}
 # Btc node user
 user =  "{{ .Data.data.rpcuser }}"
 # Btc node password


### PR DESCRIPTION
Fixed issues related to covenant signer access to bitcoin nodes
- adjusted secrets path to work with "fullnode" and "signer-node"
- removed quotes around rpcauth which was impeding rpc access
- fixed txindex
