### PR TITLE
update template to accomodate multiple chains ie. signet and mainnet

### DIFF
--- a/babylon/bitcoin-signer/wallet-load-unlock.sh.tpl
+++ b/babylon/bitcoin-signer/wallet-load-unlock.sh.tpl
@@ -71,13 +71,14 @@ sleep 10 # wait for the bitcoin node to start
 : "${BTC_NODE_IP:?Need to set BTC_NODE_IP}"
 : "${BTC_NODE_RPC_PORT:?Need to set BTC_NODE_RPC_PORT}"
 : "${BTC_WALLET_NAME:?Need to set BTC_WALLET_NAME}"
+: "${SECRETS_PATH:?Need to set SECRETS_PATH}"
 
 # Variables required for the script
 wallet_timeout=15552000 # 6 months in seconds
 wallet_name="${BTC_WALLET_NAME}"
 # this loads a wallet from designated location on the server machine
 wallet_file_path="/home/bitcoin/wallet.dat"
-{{- with secret "signing_keys/babylon/btc-signer-wallet0" }}
+{{- with secret (printf "signing_keys/%s/btc-signer-wallet0" (env "SECRETS_PATH")) }}
 passphrase="{{ .Data.data.wallet_passphrase }}"
 {{- end }}
 

--- a/babylon/bitcoin/bitcoin-conf.toml.tpl
+++ b/babylon/bitcoin/bitcoin-conf.toml.tpl
@@ -6,7 +6,7 @@ server=1
 # or use the python script here 
 # https://github.com/bitcoin/bitcoin/blob/master/share/rpcauth/README.md
 # to generate an rpcauth string
-{{- with secret (printf "static_secrets/babylon/%s" (env "BTC_NODE_TYPE")) }}
+{{- with secret (printf "static_secrets/%s/%s" (env "SECRETS_PATH") (env "BTC_NODE_TYPE")) }}
 rpcauth={{ .Data.data.rpcauth }}
 {{- end}}
 # rpc cookie file this allows authentication to only those that have access to the cookie location

--- a/babylon/covenant-signer/config.toml.tpl
+++ b/babylon/covenant-signer/config.toml.tpl
@@ -7,11 +7,11 @@
 [btc-config]
 # Btc node host
 {{- range service "bitcoin-rpc" }}
-{{- if in .Tags "fullnode" }}
+{{- if and (contains .Tags "fullnode") (contains .Tags (env "BTC_CHAIN")) }}
 host = "{{ .Address }}:{{ .Port }}"
 {{- end }}
 {{- end }}
-{{- with secret "static_secrets/babylon/fullnode" }}
+{{- with secret (printf "static_secrets/%s/fullnode" (env "SECRETS_PATH")) }}
 # Btc node user
 user = "{{ .Data.data.rpcuser }}"
 # Btc node password
@@ -23,12 +23,12 @@ network = "{{ env "BTC_CHAIN" }}"
 [btc-signer-config]
 # Btc node host
 {{- range service "bitcoin-wallet-rpc" }}
-{{- if in .Tags "signer-node" }}
+{{- if and (contains .Tags "signer-node") (contains .Tags (env "BTC_CHAIN")) }}
 host = "{{ .Address }}:{{ .Port }}"
 {{- end }}
 {{- end }}
 # TODO: consider reading user/pass from command line
-{{- with secret "static_secrets/babylon/signer-node" }}
+{{- with secret (printf "static_secrets/%s/signer-node" (env "SECRETS_PATH")) }}
 # Btc node user
 user =  "{{ .Data.data.rpcuser }}"
 # Btc node password


### PR DESCRIPTION
- Faciltates the use of babylon configs for multiple chains ie. BTC signet and mainnet
- More specifically allows more granular templating - by the chain type - of the BTC Fullnode and BTC wallet node rpc's