### PR TITLE
Interim covenant signer fix

### DIFF
--- a/babylon/covenant-signer/config.toml.tpl
+++ b/babylon/covenant-signer/config.toml.tpl
@@ -24,7 +24,6 @@ network = "{{ env "BTC_CHAIN" }}"
 # Btc node host
 {{- range service "bitcoin-wallet-rpc" }}
 {{- if .Tags | contains (env "SIGNER_JOB_NAME") }}
-{{- if contains .Tags  }}
 host = "{{ .Address }}:{{ .Port }}"
 {{- end }}
 {{- end }}

--- a/babylon/covenant-signer/config.toml.tpl
+++ b/babylon/covenant-signer/config.toml.tpl
@@ -7,7 +7,7 @@
 [btc-config]
 # Btc node host
 {{- range service "bitcoin-rpc" }}
-{{- if and (contains .Tags "fullnode") (contains .Tags (env "BTC_CHAIN")) }}
+{{- if contains .Tags (env "TXNODE_JOB_NAME") }}
 host = "{{ .Address }}:{{ .Port }}"
 {{- end }}
 {{- end }}
@@ -23,7 +23,7 @@ network = "{{ env "BTC_CHAIN" }}"
 [btc-signer-config]
 # Btc node host
 {{- range service "bitcoin-wallet-rpc" }}
-{{- if and (contains .Tags "signer-node") (contains .Tags (env "BTC_CHAIN")) }}
+{{- if contains .Tags (env "SIGNER_JOB_NAME")) }}
 host = "{{ .Address }}:{{ .Port }}"
 {{- end }}
 {{- end }}

--- a/babylon/covenant-signer/config.toml.tpl
+++ b/babylon/covenant-signer/config.toml.tpl
@@ -23,7 +23,7 @@ network = "{{ env "BTC_CHAIN" }}"
 [btc-signer-config]
 # Btc node host
 {{- range service "bitcoin-wallet-rpc" }}
-{{- if contains .Tags (env "SIGNER_JOB_NAME")) }}
+{{- if contains .Tags (env "SIGNER_JOB_NAME") }}
 host = "{{ .Address }}:{{ .Port }}"
 {{- end }}
 {{- end }}

--- a/babylon/covenant-signer/config.toml.tpl
+++ b/babylon/covenant-signer/config.toml.tpl
@@ -7,7 +7,7 @@
 [btc-config]
 # Btc node host
 {{- range service "bitcoin-rpc" }}
-{{- if contains .Tags (env "TXNODE_JOB_NAME") }}
+{{- if .Tags | contains (env "TXNODE_JOB_NAME") }}
 host = "{{ .Address }}:{{ .Port }}"
 {{- end }}
 {{- end }}
@@ -23,7 +23,8 @@ network = "{{ env "BTC_CHAIN" }}"
 [btc-signer-config]
 # Btc node host
 {{- range service "bitcoin-wallet-rpc" }}
-{{- if contains .Tags (env "SIGNER_JOB_NAME") }}
+{{- if .Tags | contains (env "SIGNER_JOB_NAME") }}
+{{- if contains .Tags  }}
 host = "{{ .Address }}:{{ .Port }}"
 {{- end }}
 {{- end }}


### PR DESCRIPTION
- covenant-signer config.toml.tpl was not templating the consul services and capturing the host:port as required
- amended now to receive env vars from nomad job of the btc-fullnode and the btc-wallet-nodes
- @dpdanpittman please complete this pr as the template will need to be merged into main