### PR TITLE
update cosmos sdk rest port in v50 config

### DIFF
--- a/cosmos-sdk/0.50.x/app.toml.tpl
+++ b/cosmos-sdk/0.50.x/app.toml.tpl
@@ -125,7 +125,7 @@ enable = true
 swagger = {{ keyOrDefault (print (env "CONSUL_PATH") "/api.swagger") "false" }}
 
 # Address defines the API server to listen on.
-address = "tcp://0.0.0.0:{{ env "NOMAD_PORT_leet" }}"
+address = "tcp://0.0.0.0:{{ env "NOMAD_PORT_rest" }}"
 
 # MaxOpenConnections defines the number of maximum open connections.
 max-open-connections = 1000


### PR DESCRIPTION
Update `app.toml` config template to account for the port name change in the new nomad job template.