### PR TITLE
Add distinct env var for Covenant Network in the config

### DIFF
--- a/babylon/covenant-signer/config.toml.tpl
+++ b/babylon/covenant-signer/config.toml.tpl
@@ -41,7 +41,7 @@ user =  "{{ .Data.data.rpcuser }}"
 pass =  "{{ .Data.data.rpcpassword }}"
 {{- end }}
 # Btc network (testnet3|mainnet|regtest|simnet|signet)
-network = "{{ env "BTC_CHAIN" }}"
+network = "{{ env "COVENANT_NETWORK" }}"
 
 [server-config]
 # The address to listen on


### PR DESCRIPTION
- needed to amend config to account for the different naming convention for btc mainnet 
- btc uses "main" as the designated main network for bitcoin and not "mainnet"
- the covenant signer uses "mainnet" as the designation for operating on the btc main network as a result we have added a env var to our jobs distinct from BTC_CHAIN which allows the covenant signer network to be set to "mainnet" or another covenant signer network