### PR TITLE
update ports in SDK config

### DIFF
--- a/cosmos-sdk/0.45.x/app.toml.tpl
+++ b/cosmos-sdk/0.45.x/app.toml.tpl
@@ -118,7 +118,7 @@ enable = true
 swagger = true
 
 # Address defines the API server to listen on.
-address = "tcp://0.0.0.0:{{ env "NOMAD_PORT_leet" }}"
+address = "tcp://0.0.0.0:1317"
 
 # MaxOpenConnections defines the number of maximum open connections.
 max-open-connections = 1000
@@ -169,7 +169,7 @@ offline = false
 enable = true
 
 # Address defines the gRPC server address to bind to.
-address = "0.0.0.0:{{ env "NOMAD_PORT_grpc" }}"
+address = "0.0.0.0:9090"
 
 # MaxRecvMsgSize defines the max message size in bytes the server can receive.
 # The default value is 4MB.

--- a/cosmos-sdk/0.45.x/config.toml.tpl
+++ b/cosmos-sdk/0.45.x/config.toml.tpl
@@ -91,7 +91,7 @@ filter_peers = false
 [rpc]
 
 # TCP or UNIX socket address for the RPC server to listen on
-laddr = "tcp://0.0.0.0:{{ env "NOMAD_PORT_rpc" }}"
+laddr = "tcp://0.0.0.0:26657"
 
 # A list of origins a cross-domain request can be executed from
 # Default value '[]' disables cors support
@@ -194,7 +194,7 @@ tls_cert_file = ""
 tls_key_file = ""
 
 # pprof listen address (https://golang.org/pkg/net/http/pprof)
-pprof_laddr = "0.0.0.0:{{ env "NOMAD_PORT_pprof" }}"
+pprof_laddr = "0.0.0.0:6060"
 
 #######################################################
 ###           P2P Configuration Options             ###
@@ -457,7 +457,7 @@ psql-conn = {{ keyOrDefault  (print (env "CONSUL_PATH") "/tx_index.psql-conn") "
 prometheus = true
 
 # Address to listen for Prometheus collector(s) connections
-prometheus_listen_addr = ":{{ env "NOMAD_PORT_prom" }}"
+prometheus_listen_addr = "0.0.0.0:26660"
 
 # Maximum number of simultaneous connections.
 # If you want to accept a larger number than the default, make sure

--- a/cosmos-sdk/0.46.x/app.toml.tpl
+++ b/cosmos-sdk/0.46.x/app.toml.tpl
@@ -123,7 +123,7 @@ enable = true
 swagger = true
 
 # Address defines the API server to listen on.
-address = "tcp://0.0.0.0:{{ env "NOMAD_PORT_leet" }}"
+address = "tcp://0.0.0.0:1317"
 
 # MaxOpenConnections defines the number of maximum open connections.
 max-open-connections = 1000
@@ -186,7 +186,7 @@ denom-to-suggest = {{ keyOrDefault (print (env "CONSUL_PATH") "/base.denom-to-su
 enable = true
 
 # Address defines the gRPC server address to bind to.
-address = "0.0.0.0:{{ env "NOMAD_PORT_grpc" }}"
+address = "0.0.0.0:9090"
 
 # MaxRecvMsgSize defines the max message size in bytes the server can receive.
 # The default value is 10MB.

--- a/cosmos-sdk/0.46.x/config.toml.tpl
+++ b/cosmos-sdk/0.46.x/config.toml.tpl
@@ -91,7 +91,7 @@ filter_peers = false
 [rpc]
 
 # TCP or UNIX socket address for the RPC server to listen on
-laddr = "tcp://0.0.0.0:{{ env "NOMAD_PORT_rpc" }}"
+laddr = "tcp://0.0.0.0:26657"
 
 # A list of origins a cross-domain request can be executed from
 # Default value '[]' disables cors support
@@ -194,7 +194,7 @@ tls_cert_file = ""
 tls_key_file = ""
 
 # pprof listen address (https://golang.org/pkg/net/http/pprof)
-pprof_laddr = "0.0.0.0:{{ env "NOMAD_PORT_pprof" }}"
+pprof_laddr = "0.0.0.0:6060"
 
 #######################################################
 ###           P2P Configuration Options             ###
@@ -457,7 +457,7 @@ psql-conn = {{ keyOrDefault  (print (env "CONSUL_PATH") "/tx_index.psql-conn") "
 prometheus = true
 
 # Address to listen for Prometheus collector(s) connections
-prometheus_listen_addr = ":{{ env "NOMAD_PORT_prom" }}"
+prometheus_listen_addr = "0.0.0.0:26660"
 
 # Maximum number of simultaneous connections.
 # If you want to accept a larger number than the default, make sure

--- a/cosmos-sdk/0.47.x/app.toml.tpl
+++ b/cosmos-sdk/0.47.x/app.toml.tpl
@@ -126,7 +126,7 @@ enable = true
 swagger = true
 
 # Address defines the API server to listen on.
-address = "tcp://0.0.0.0:{{ env "NOMAD_PORT_leet" }}"
+address = "tcp://0.0.0.0:1317"
 
 # MaxOpenConnections defines the number of maximum open connections.
 max-open-connections = 1000
@@ -189,7 +189,7 @@ denom-to-suggest = {{ keyOrDefault (print (env "CONSUL_PATH") "/rosetta.denom-to
 enable = true
 
 # Address defines the gRPC server address to bind to.
-address = "0.0.0.0:{{ env "NOMAD_PORT_grpc" }}"
+address = "0.0.0.0:9090"
 
 # MaxRecvMsgSize defines the max message size in bytes the server can receive.
 # The default value is 10MB.

--- a/cosmos-sdk/0.47.x/config.toml.tpl
+++ b/cosmos-sdk/0.47.x/config.toml.tpl
@@ -93,7 +93,7 @@ filter_peers = false
 [rpc]
 
 # TCP or UNIX socket address for the RPC server to listen on
-laddr = "tcp://0.0.0.0:{{ env "NOMAD_PORT_rpc" }}"
+laddr = "tcp://0.0.0.0:26657"
 
 # A list of origins a cross-domain request can be executed from
 # Default value '[]' disables cors support
@@ -196,7 +196,7 @@ tls_cert_file = ""
 tls_key_file = ""
 
 # pprof listen address (https://golang.org/pkg/net/http/pprof)
-pprof_laddr = "0.0.0.0:{{ env "NOMAD_PORT_pprof" }}"
+pprof_laddr = "0.0.0.0:6060"
 
 #######################################################
 ###           P2P Configuration Options             ###
@@ -461,7 +461,7 @@ psql-conn = {{ keyOrDefault  (print (env "CONSUL_PATH") "/tx_index.psql-conn") "
 prometheus = true
 
 # Address to listen for Prometheus collector(s) connections
-prometheus_listen_addr = ":{{ env "NOMAD_PORT_prom" }}"
+prometheus_listen_addr = "0.0.0.0:26660"
 
 # Maximum number of simultaneous connections.
 # If you want to accept a larger number than the default, make sure

--- a/cosmos-sdk/0.50.x/app.toml.tpl
+++ b/cosmos-sdk/0.50.x/app.toml.tpl
@@ -125,7 +125,7 @@ enable = true
 swagger = {{ keyOrDefault (print (env "CONSUL_PATH") "/api.swagger") "false" }}
 
 # Address defines the API server to listen on.
-address = "tcp://0.0.0.0:{{ env "NOMAD_PORT_rest" }}"
+address = "tcp://0.0.0.0:1317"
 
 # MaxOpenConnections defines the number of maximum open connections.
 max-open-connections = 1000
@@ -152,7 +152,7 @@ enabled-unsafe-cors = false
 enable = true
 
 # Address defines the gRPC server address to bind to.
-address = "0.0.0.0:{{ env "NOMAD_PORT_grpc" }}"
+address = "0.0.0.0:9090"
 
 # MaxRecvMsgSize defines the max message size in bytes the server can receive.
 # The default value is 10MB.

--- a/cosmos-sdk/0.50.x/config.toml.tpl
+++ b/cosmos-sdk/0.50.x/config.toml.tpl
@@ -86,7 +86,7 @@ filter_peers = false
 [rpc]
 
 # TCP or UNIX socket address for the RPC server to listen on
-laddr = "tcp://0.0.0.0:{{ env "NOMAD_PORT_rpc" }}"
+laddr = "tcp://0.0.0.0:26657"
 
 # A list of origins a cross-domain request can be executed from
 # Default value '[]' disables cors support
@@ -189,7 +189,7 @@ tls_cert_file = ""
 tls_key_file = ""
 
 # pprof listen address (https://golang.org/pkg/net/http/pprof)
-pprof_laddr = "0.0.0.0:{{ env "NOMAD_PORT_pprof" }}"
+pprof_laddr = "0.0.0.0:6060"
 
 #######################################################
 ###           P2P Configuration Options             ###
@@ -469,7 +469,7 @@ psql-conn = {{ keyOrDefault  (print (env "CONSUL_PATH") "/tx_index.psql-conn") "
 prometheus = true
 
 # Address to listen for Prometheus collector(s) connections
-prometheus_listen_addr = ":{{ env "NOMAD_PORT_prom" }}"
+prometheus_listen_addr = "0.0.0.0:26660"
 
 # Maximum number of simultaneous connections.
 # If you want to accept a larger number than the default, make sure


### PR DESCRIPTION
Change SDK config template to use default values instead of parametrized values.

Updated only configs for > v0.45 as there are no more chains that use older versions.