### PR TITLE
Update oracle-testnet config api urls

### DIFF
--- a/slinky/1.0.5/oracle-testnet.tpl
+++ b/slinky/1.0.5/oracle-testnet.tpl
@@ -4,10 +4,10 @@
       "api": {
         "endpoints": [
           {
-            "url":  {{ range service "dydx-validator.cosmos-sdk-rest" }}"http://{{ .Address }}:{{ .Port }}"{{ end }}
+            "url":  {{ range service "dydx-testnet-validator.cosmos-sdk-rest" }}"http://{{ .Address }}:{{ .Port }}"{{ end }}
           },
           {
-            "url":  {{ range service "dydx-validator.cosmos-sdk-grpc" }}"{{ .Address }}:{{ .Port }}"{{ end }}
+            "url":  {{ range service "dydx-testnet-validator.cosmos-sdk-grpc" }}"{{ .Address }}:{{ .Port }}"{{ end }}
           }
         ]
       }


### PR DESCRIPTION
This updates the api endpoint urls to reflect the actual job name. `dydx-testnet-validator`