### PR TITLE
Update Cosmos SDK v0.46.x tpl for Celestia mocha-4 upgrade

### DIFF
--- a/cosmos-sdk/0.46.x/config.toml.tpl
+++ b/cosmos-sdk/0.46.x/config.toml.tpl
@@ -15,7 +15,7 @@
 
 # TCP or UNIX socket address of the ABCI application,
 # or the name of an ABCI application compiled in with the Tendermint binary
-proxy_app = "tcp://127.0.0.1:26658"
+proxy_app = {{ keyOrDefault (print (env "CONSUL_PATH") "/base.proxy_app") "\"tcp://127.0.0.1:26658\"" }}
 
 # A custom human readable name for this node
 moniker = {{ keyOrDefault (print (env "CONSUL_PATH") "/base.moniker") "\"20k leagues under the sea\"" }}


### PR DESCRIPTION
Updates the `proxy_app` address to be configurable via Consul. 

Celestia mocha-4 testnet upgrade requires us to set a new value for `proxy_app` requiring the use of `keyOrDefault` in our `v0.46.x` Cosmos SDK template.