### PR TITLE
Update Cosmos SDK v0.46.x tpl - Update grpc_laddr to use keyOrDefault 

### DIFF
--- a/cosmos-sdk/0.46.x/config.toml.tpl
+++ b/cosmos-sdk/0.46.x/config.toml.tpl
@@ -106,7 +106,7 @@ cors_allowed_headers = ["Origin", "Accept", "Content-Type", "X-Requested-With", 
 
 # TCP or UNIX socket address for the gRPC server to listen on
 # NOTE: This server only supports /broadcast_tx_commit
-grpc_laddr = ""
+grpc_laddr = {{ keyOrDefault (print (env "CONSUL_PATH") "/rpc.grpc_laddr") "\"\"" }}
 
 # Maximum number of simultaneous connections.
 # Does not include RPC (HTTP&WebSocket) connections. See max_open_connections


### PR DESCRIPTION
After upgrading our mocha-4 testnet archive0 node, we're getting this error: 

```Error: must set the RPC GRPC listen address in config.toml (grpc_laddr) or by flag (--rpc.grpc_laddr)```

This PR configures the gRPC listening address using a value retrieved from Consul. This allows for dynamic configuration of the gRPC endpoint.

in `v0.46.x` cosmos sdk, `grpc_laddr = ""`

think we should do this:

```grpc_laddr = {{ keyOrDefault (print (env "CONSUL_PATH") "/rpc.grpc_laddr") "\"\"" }}```

and then use:

consul kv put networks/mocha-4/archive0/rpc.grpc_laddr "tcp://0.0.0.0:${NOMAD_PORT_grpc}"

can someone confirm this is correct?

nomad job shows:

`port "grpc" { to = 9090 }`

for the archive0.nomad job