### PR TITLE
Bs/update cometbft v0.38.x grpc

### DIFF
--- a/cometbft/v0.38.x
+++ b/cometbft/v0.38.x
@@ -104,7 +104,7 @@ cors_allowed_headers = ["Origin", "Accept", "Content-Type", "X-Requested-With", 
 
 # TCP or UNIX socket address for the gRPC server to listen on
 # NOTE: This server only supports /broadcast_tx_commit
-grpc_laddr = ""
+grpc_laddr = {{ keyOrDefault (print (env "CONSUL_PATH") "/rpc.grpc_laddr") "\"\"" }}
 
 # Maximum number of simultaneous connections.
 # Does not include RPC (HTTP&WebSocket) connections. See max_open_connections

--- a/cosmos-sdk/0.46.x/config.toml.tpl
+++ b/cosmos-sdk/0.46.x/config.toml.tpl
@@ -15,7 +15,7 @@
 
 # TCP or UNIX socket address of the ABCI application,
 # or the name of an ABCI application compiled in with the Tendermint binary
-proxy_app = {{ keyOrDefault (print (env "CONSUL_PATH") "/base.proxy_app") "\"tcp://127.0.0.1:26658\"" }}
+proxy_app = "tcp://127.0.0.1:26658"
 
 # A custom human readable name for this node
 moniker = {{ keyOrDefault (print (env "CONSUL_PATH") "/base.moniker") "\"20k leagues under the sea\"" }}
@@ -106,7 +106,7 @@ cors_allowed_headers = ["Origin", "Accept", "Content-Type", "X-Requested-With", 
 
 # TCP or UNIX socket address for the gRPC server to listen on
 # NOTE: This server only supports /broadcast_tx_commit
-grpc_laddr = {{ keyOrDefault (print (env "CONSUL_PATH") "/rpc.grpc_laddr") "\"\"" }}
+grpc_laddr = ""
 
 # Maximum number of simultaneous connections.
 # Does not include RPC (HTTP&WebSocket) connections. See max_open_connections


### PR DESCRIPTION
Reverts changes to Cosmos SDK v0.46.x (restores default values), and updates `grpc_laddr` for CometBFT v0.38.x to use `keyOrDefault` (required to set a value for celestia mocha-4 testnet node).